### PR TITLE
-assoc and -get in cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/resources
 /target
 /classes
 /checkouts

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ From a browser (you need IndexedDB available in your js env) or analogous from a
 
 ~~~clojure
 (ns test-db
-  (:require [konserve.platform :refer [new-indexeddb-store]))
+  (:require [konserve.platform :refer [new-indexeddb-store]]))
 
 (go (def my-db (<! (new-indexeddb-store "konserve"))))
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.polyc0l0r/konserve "0.1.0"
+(defproject viebel/konserve "0.1.2"
   :description "Durable key-value store protocol with core.async."
   :url "http://github.com/ghubber/konserve"
   :license {:name "Eclipse Public License"

--- a/src/cljs/konserve/platform.cljs
+++ b/src/cljs/konserve/platform.cljs
@@ -2,8 +2,8 @@
   "Platform specific io operations cljs."
   (:require [konserve.protocols :refer [IAsyncKeyValueStore -get-in -assoc-in -update-in]]
             [cljs.reader :refer [read-string]]
-            [cljs.core.async :as async :refer (take! put! close! chan)])
-  (:require-macros [cljs.core.async.macros :refer [<! >! go go-loop]]))
+            [cljs.core.async :as async :refer (take! <! >! put! close! chan)])
+  (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
 
 
 (defn log [& s]
@@ -12,7 +12,6 @@
 
 (defn error-handler [topic res e]
   (.log js/console topic e) (close! res) (throw e))
-
 
 (defrecord IndexedDBKeyValueStore [db store-name]
   IAsyncKeyValueStore
@@ -26,10 +25,10 @@
             (partial error-handler (str "cannot get-in" fkey) res))
       (set! (.-onsuccess req)
             (fn [e] (when-let [r (.-result req)]
-                     (put! res(-> r
-                                  .-edn_value
-                                  read-string
-                                  (get-in rkey))))
+                      (put! res (-> r
+                                      (aget "edn_value")
+                                      read-string
+                                      (get-in rkey))))
               ;; returns nil
               (close! res)))
       res))
@@ -44,7 +43,7 @@
       (set! (.-onsuccess req)
             (fn read-old [e]
               (let [old (when-let [r (.-result req)]
-                          (-> r .-edn_value read-string))
+                          (-> r (aget "edn_value") read-string))
                     up-req (if (or value (not (empty? rkey)))
                              (.put obj-store
                                    (clj->js {:key (pr-str fkey)
@@ -69,7 +68,7 @@
       (set! (.-onsuccess req)
             (fn read-old [e]
               (let [old (when-let [r (.-result req)]
-                          (-> r .-edn_value read-string))
+                          (-> r (aget "edn_value") read-string))
                     new (if-not (empty? rkey)
                           (update-in old rkey up-fn)
                           (up-fn old))
@@ -77,6 +76,78 @@
                              (.put obj-store
                                    (clj->js {:key (pr-str fkey)
                                              :edn_value
+                                             (pr-str new)}))
+                             (.delete obj-store (pr-str fkey)))]
+                (set! (.-onerror up-req)
+                      (partial error-handler (str "cannot put for update-in" fkey) res))
+                (set! (.-onsuccess up-req)
+                      (fn [e]
+                        (put! res [(get-in old rkey) (get-in new rkey)])
+                        (close! res))))))
+      res)))
+
+(defrecord IndexedDBJSONKeyValueStore [db store-name]
+  IAsyncKeyValueStore
+  (-get-in [this key-vec]
+    (let [[fkey & rkey] key-vec
+          res (chan)
+          tx (.transaction db #js [store-name])
+          obj-store (.objectStore tx store-name)
+          req (.get obj-store (pr-str fkey))]
+      (set! (.-onerror req)
+            (partial error-handler (str "cannot get-in" fkey) res))
+      (set! (.-onsuccess req)
+            (fn [e] (when-let [r (.-result req)]
+                      (put! res (-> r
+                                    (aget "json_value")
+                                    js->clj
+                                    (get-in rkey))))
+              ;; returns nil
+              (close! res)))
+      res))
+  (-assoc-in [this key-vec value]
+    (let [[fkey & rkey] key-vec
+          res (chan)
+          tx (.transaction db #js [store-name] "readwrite")
+          obj-store (.objectStore tx store-name)
+          req (.get obj-store (pr-str fkey))]
+      (set! (.-onerror req)
+            (partial error-handler (str "cannot get for assoc-in" fkey) res))
+      (set! (.-onsuccess req)
+            (fn read-old [e]
+              (let [old (when-let [r (.-result req)]
+                          (js->clj (-> r (aget "json_value"))))
+                    up-req (if (or value (not (empty? rkey)))
+                             (.put obj-store
+                                   #js {:key (pr-str fkey)
+                                        :json_value (if-not (empty? rkey)
+                                                      (clj->js (assoc-in old rkey value))
+                                                      value)})
+                             (.delete obj-store (pr-str fkey)))]
+                (set! (.-onerror up-req)
+                      (partial error-handler (str "cannot put for assoc-in" fkey) res))
+                (set! (.-onsuccess up-req)
+                      (fn [e] (close! res))))))
+      res))
+  (-update-in [this key-vec up-fn]
+    (let [[fkey & rkey] key-vec
+          res (chan)
+          tx (.transaction db #js [store-name] "readwrite")
+          obj-store (.objectStore tx store-name)
+          req (.get obj-store (pr-str fkey))]
+      (set! (.-onerror req)
+            (partial error-handler (str "cannot get for update-in" fkey) res))
+      (set! (.-onsuccess req)
+            (fn read-old [e]
+              (let [old (when-let [r (.-result req)]
+                          (-> r (aget "json_value")))
+                    new (if-not (empty? rkey)
+                          (update-in old rkey up-fn)
+                          (up-fn old))
+                    up-req (if new
+                             (.put obj-store
+                                   (clj->js {:key (pr-str fkey)
+                                             :json_value
                                              (pr-str new)}))
                              (.delete obj-store (pr-str fkey)))]
                 (set! (.-onerror up-req)
@@ -103,6 +174,31 @@
               (.createObjectStore db name #js {:keyPath "key"}))
             (log "db upgraded from version: " (.-oldVersion e))))
     res))
+
+(defn create-store [type db store-name]
+  (log "create-store" type)
+  (case type
+    :edn (IndexedDBKeyValueStore. db store-name)
+    :json (IndexedDBJSONKeyValueStore. db store-name)))
+
+(defn new-indexeddb-store 
+  ([name type]
+  (let [res (chan)
+        req (.open js/window.indexedDB name 1)]
+    (set! (.-onerror req)
+          (partial error-handler "ERROR opening DB:" res))
+    (set! (.-onsuccess req)
+          (fn success-handler [e]
+            (log "db-opened:" (.-result req))
+            (put! res (create-store type (.-result req) name))))
+    (set! (.-onupgradeneeded req)
+          (fn upgrade-handler [e]
+            (let [db (-> e .-target .-result)]
+              (.createObjectStore db name #js {:keyPath "key"}))
+            (log "db upgraded from version: " (.-oldVersion e))))
+    res))
+  ([name] 
+   (new-indexeddb-store name :edn)))
 
 
 (comment

--- a/src/cljx/konserve/protocols.cljx
+++ b/src/cljx/konserve/protocols.cljx
@@ -4,3 +4,4 @@
   (-get-in [this key-vec] "Returns the value stored described by key-vec or nil if the path is not resolvable.")
   (-assoc-in [this key-vec value] "Associates the key-vec to the value, any missing collections for the key-vec (nested maps and vectors) are newly created.")
   (-update-in [this key-vec up-fn] "Updates a position described by key-vec by applying up-fn and storing the result atomically. Returns a vector [old new] of the previous value and the result of applying up-fn (the newly stored value)." ))
+


### PR DESCRIPTION
-assoc-in and -get-in works with edn
When we deal with large part of data it causes a performance hit.
-assoc and -get works with JSON.
